### PR TITLE
Set image fill mode to preserve aspect ratio.

### DIFF
--- a/Magna SplashScreen/Magna-Splash/contents/splash/Splash.qml
+++ b/Magna SplashScreen/Magna-Splash/contents/splash/Splash.qml
@@ -3,6 +3,7 @@ import QtQuick 2.5
 Image {
     id: root
     source: "images/background.png"
+    fillMode: Image.PreserveAspectCrop
 
     property int stage
 


### PR DESCRIPTION
Change the fill mode so that image is not squished on displays that are not exactly the aspect ratio of images/background.png